### PR TITLE
fix(make metadata truncation insensitive to type)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
 test:
   override:
     # only diff branch changes
-    - git diff master | flake8 --diff --output-file=$CIRCLE_TEST_REPORTS/flake8/report.txt history/
+    - git diff master -- '*.py' | flake8 --diff --output-file=$CIRCLE_TEST_REPORTS/flake8/report.txt history/
     - >
       nosetests -v --with-timer
       --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/nosetests/tests.xml

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'history'
-__version__ = '0.9.9'
+__version__ = '0.9.10'

--- a/history/storage.py
+++ b/history/storage.py
@@ -52,7 +52,7 @@ def _truncate_metadata_fields(metadata, max_length=400):
     truncated_fields = {}
     # s3_key.update_metadata(metadata) #=> can't use this as need to cast to unicode
     for k, v in metadata.items():
-        v = unicode(v)
+        v = u'' + str(v)
         v = v[:max_length] + '...' if len(v) > max_length else v
         truncated_fields[k] = v
     return truncated_fields
@@ -167,7 +167,8 @@ class S3CacheStorage(object):
         if not s3_key:
             return
 
-        logger.info(' (epoch => {epoch}): retrieving response for {url}.'.format(epoch=epoch, url=request.url))
+        logger.info(' (epoch => {epoch}): retrieving response for {url}.'.format(epoch=epoch,
+                                                                                 url=request.url))
         try:
             data_string = s3_key.get_contents_as_string()
         except boto.exception.S3ResponseError as e:
@@ -181,7 +182,7 @@ class S3CacheStorage(object):
         metadata = data['metadata']
         response_headers = Headers(data['response_headers'])
         response_body = data['response_body']
-        
+
         if data.get('binary', False):
             logger.debug('retrieved binary body')
             response_body = base64.b64decode(response_body.decode('utf8'))

--- a/history/storage.py
+++ b/history/storage.py
@@ -52,8 +52,9 @@ def _truncate_metadata_fields(metadata, max_length=400):
     truncated_fields = {}
     # s3_key.update_metadata(metadata) #=> can't use this as need to cast to unicode
     for k, v in metadata.items():
+        v = unicode(v)
         v = v[:max_length] + '...' if len(v) > max_length else v
-        truncated_fields[k] = unicode(v)
+        truncated_fields[k] = v
     return truncated_fields
 
 


### PR DESCRIPTION
Make parsing of metadata fields for S3 more robust, as it was failing on some fields that were not unicode.