### PR TITLE
Prevent the extension to crash on failure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2012 (c) developers and contibutors. All rights reserved.
+Copyright 2017 (c) developers and contibutors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-scrapy-history-middleware
+Scrapy History Middleware
 =========================
 
 [![CircleCI](https://circleci.com/gh/Kpler/scrapy-history-middleware.svg?style=svg)](https://circleci.com/gh/Kpler/scrapy-history-middleware)
@@ -28,7 +28,7 @@ example:
     HTTPCACHE_IGNORE_MISSING = False
 ```
 
-Will store and retrieve responses exactly as you expect. However, even
+will store and retrieve responses exactly as you expect. However, even
 if multiple developers are working on the same spider, the spidered
 website will only ever see one request (so long as they all use the
 same S3 bucket).
@@ -37,18 +37,6 @@ Scrapy introduced the `DbmCacheStorage` backend in version 0.13. In
 principle this is capable of interfacing with S3, but the history
 middleware is still necessary as it provides versioning capability.
 
-## Requirements
-
-To run the middleware:
-
-  * `parsedatetime`
-  * `boto`. If using the S3 storage backend.
-
-Testing:
-
-  * `nose`
-  * `nose-cov`
-  * `coverage`
 
 ## Config
 
@@ -58,56 +46,55 @@ middleware. As such, the default logic modules use
 `HTTPCACHE_IGNORE_HTTP_CODES`, and responses will not be stored if
 they are flagged as having returned from the cache storage.
 
-### Epoch
 
-# Settings:
+## Settings
 
-  * `HISTORY_USE_PROXY`:
-    Usage: HISTORY_EPOCH can either be defined in `settings.py`,
-    `local_settings.py`, or on the command line, eg.,:
+* `HISTORY_USE_PROXY`: can either be defined in `settings.py`,
+  `local_settings.py`, or on the command line:
+
+  ```bash
+  $ scrapy crawl {{ spider }} --set="HISTORY_EPOCH=yesterday"
+  ```
   
-    ```bash
-  	$ scrapy crawl {{ spider }} --set="HISTORY_EPOCH=yesterday"
-    ```
-    
-    Note that scrapy will choose the value in local_settings.py over the
-    command line.
+  Note that scrapy will choose the value in local_settings.py over the
+  command line.
 
-    Possible values:
-  
-      * `True`: The middleware will always try to retrieve the most
-        recently stored version of a url, subject to the logic in
-        `RETRIEVE_IF`.
+  Possible values:
 
-      * `False` (default): The middleware won't ever try to retrieve
-        stored responses.
+    * `True`: The middleware will always try to retrieve the most
+      recently stored version of a url, subject to the logic in
+      `RETRIEVE_IF`.
 
-      * `{{ string }}`: The middleware will attempt to generate a datetime
-        using the heuristics of the
-        [parsedatetime](http://code.google.com/p/parsedatetime/)
-        module. The retrieved response will either be newer than `EPOCH`,
-        or the most recently stored response.
+    * `False` (default): The middleware won't ever try to retrieve
+      stored responses.
 
-  * `HISTORY_STORE_IF`: (default `history.logic.StoreAlways`) Path to a
-    callable that accepts the current spider, request, and response as
-    arguments and returns `True` if the response should be stored, or
-    `False` otherwise.
+    * `{{ string }}`: The middleware will attempt to generate a datetime
+      using the heuristics of the
+      [parsedatetime](http://code.google.com/p/parsedatetime/)
+      module. The retrieved response will either be newer than `EPOCH`,
+      or the most recently stored response.
 
-  * `HISTORY_RETRIEVE_IF`: (default `history.logic.RetrieveNever`) Path to a
-    callable that accepts the current spider and request as arguments
-    and returns `True` if the response should be retrieved from the
-    storage backend, or `False` otherwise.
+* `HISTORY_STORE_IF`: (default `history.logic.StoreAlways`) Path to a
+  callable that accepts the current spider, request, and response as
+  arguments and returns `True` if the response should be stored, or
+  `False` otherwise.
 
-  * `HISTORY_BACKEND`: (default `history.storage.S3CacheStorage`) The storage
-    backend.
+* `HISTORY_RETRIEVE_IF`: (default `history.logic.RetrieveNever`) Path to a
+  callable that accepts the current spider and request as arguments
+  and returns `True` if the response should be retrieved from the
+  storage backend, or `False` otherwise.
 
-  * `S3_ACCESS_KEY`: Required if using `S3CacheStorage`.
+* `HISTORY_BACKEND`: (default `history.storage.S3CacheStorage`) The storage
+  backend.
 
-  * `S3_BUCKET_KEY`: Required if using `S3CacheStorage`.
+* `S3_ACCESS_KEY`: Required if using `S3CacheStorage`.
 
-  * `HISTORY_S3_BUCKET`: Required if using `S3CacheStorage`.
+* `S3_BUCKET_KEY`: Required if using `S3CacheStorage`.
 
-  * `HISTORY_USE_PROXY`: Mention if boto should be using a proxy to connect to the S3 bucket
+* `HISTORY_S3_BUCKET`: Required if using `S3CacheStorage`.
+
+* `HISTORY_USE_PROXY`: Mention if boto should be using a proxy to connect to the S3 bucket
+
 
 ## Using it with Scrapinghub
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 --requirement requirements.txt
 
-coverage==4.3.4
+coverage==4.4.1
 flake8==3.3.0
 ipdb==0.10.3
 nose==1.3.7
 nose-timer==0.5
-isort==4.2.5
+isort==4.2.15

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__title__ = 'history'
-__version__ = '0.10.0'
+__package__ = 'scrapyhistory'
+__version__ = '0.10.2'

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'history'
-__version__ = '0.9.10'
+__version__ = '0.10.0'

--- a/history/logic.py
+++ b/history/logic.py
@@ -2,12 +2,12 @@
 
 from datetime import datetime
 
-from scrapy.conf import settings
 from scrapy.utils.httpobj import urlparse_cached
 
 
 class LogicBase(object):
-    def __init__(self, settings=settings):
+
+    def __init__(self, settings):
         self.ignore_missing = settings.getbool('HTTPCACHE_IGNORE_MISSING', False)
         self.ignore_schemes = settings.getlist('HTTPCACHE_IGNORE_SCHEMES', ['file'])
         self.ignore_http_codes = map(int, settings.getlist('HTTPCACHE_IGNORE_HTTP_CODES', []))

--- a/history/storage.py
+++ b/history/storage.py
@@ -167,8 +167,6 @@ class S3CacheStorage(object):
         if not s3_key:
             return
 
-        logger.info('(epoch => {epoch}): retrieving response for {url}.'.format(epoch=epoch,
-                                                                                url=request.url))
         try:
             data_string = s3_key.get_contents_as_string()
         except boto.exception.S3ResponseError as e:
@@ -191,9 +189,8 @@ class S3CacheStorage(object):
             encoding = {'encoding': 'utf8'}
         url = str(metadata['response_url'])
         status = metadata.get('status')
-        logger.debug('response headers {}'.format(response_headers))
         Response = responsetypes.from_args(headers=response_headers, url=url)
-        logger.debug('response type {}'.format(Response))
+
         return Response(url=url,
                         headers=response_headers,
                         status=status,
@@ -204,13 +201,9 @@ class S3CacheStorage(object):
         """Store the given response in the cache.
 
         """
-        logger.info('storing response for {}.'.format(request.url))
+        logger.debug('storing response for {}.'.format(request.url))
         key = self._get_request_storage_key(spider, request)
-        logger.debug('response type {}'.format(type(response)))
         response_body, binary = _reformat_response(response)
-
-        logger.debug('request header {}'.format(request.headers))
-        logger.debug('response header {}'.format(response.headers))
 
         metadata = {
             'url': request.url,

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ requires = [
 ]
 
 setup(
-    name='scrapyhistory',
+    name=history.__package__,
     version=history.__version__,
     description='Scrapy downloader middleware to enable persistent storage.',
     author='Andrew Preston',
     author_email='andrew@preston.co.nz',
-    url='http://github.com/playandbuild/scrapy-history-middleware',
+    url='http://github.com/Kpler/scrapy-history-middleware',
     packages=packages,
     install_requires=requires,
     classifiers=(

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -24,7 +24,14 @@ class TestHistoryMiddleware(unittest.TestCase):
         with self.assertRaises(NotConfigured):
             self.middleware = HistoryMiddleware(get_crawler())
 
-    def test_parse_epoch(self):
-        self.assertIsInstance(
-            self.middleware.parse_epoch('yesterday'),
-            datetime)
+    def test_parse_booleannd_dt_epoch(self):
+        self.assertTrue(HistoryMiddleware.parse_epoch('True'))
+        self.assertFalse(HistoryMiddleware.parse_epoch('False'))
+        self.assertTrue(HistoryMiddleware.parse_epoch(True))
+        self.assertFalse(HistoryMiddleware.parse_epoch(False))
+
+        some_dt = datetime.now()
+        self.assertEqual(HistoryMiddleware.parse_epoch(some_dt), some_dt)
+
+    def test_parse_human_epoch(self):
+        self.assertIsInstance(self.middleware.parse_epoch('yesterday'), datetime)


### PR DESCRIPTION
### Context

This extension is a powerful debugging tool. But as a tool, it should never prevent a scraper to work because of internal failure. Instead it should just be deactivated. This PR tries aggressively to do so by catching global exceptions while processing requests.

It doesn't catch however opening and closing methods. Since they mostly depend on S3 connection, and given that S3 is a weel spread item storage, we can be assure that if this step fail, we are in a very wrong state anyway.

But this PR is opened early to discuss that, and the design of the implementation.

---

In the process of this change, two deprecation messages were fixed:

- `import scrapy.conf`
- `scrapy dispatch` 

And a few style-related stuff were fixed. You can ignore that noise.