### PR TITLE
Make code compatible with Python 2.7 and Python >=3.6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,18 +4,17 @@ dependencies:
   pre:
     # setup test env/isolation
     - mkdir -p $CIRCLE_TEST_REPORTS/flake8
-    - mkdir -p $CIRCLE_TEST_REPORTS/nosetests
-    - mkdir -p $CIRCLE_TEST_REPORTS/coverage
     # install actual dependencies
     - pip install --upgrade pip
     - pip install --upgrade -r dev-requirements.txt
 
+  override:
+    # tell tox to use pyenv
+    - pyenv local 2.7.12 3.6.1
+
 test:
   override:
+
     # only diff branch changes
     - git diff master -- '*.py' | flake8 --diff --output-file=$CIRCLE_TEST_REPORTS/flake8/report.txt history/
-    - >
-      nosetests -v --with-timer
-      --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/nosetests/tests.xml
-      --with-coverage --cover-min-percentage=37 --cover-html --cover-erase --cover-package=history
-      --cover-html-dir=$CIRCLE_TEST_REPORTS/coverage/history
+    - tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,8 @@
 coverage==4.4.1
 flake8==3.3.0
 ipdb==0.10.3
+isort==4.2.15
 nose==1.3.7
 nose-timer==0.5
-isort==4.2.15
+tox-pyenv==1.1.0
+tox==3.0.0

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 __package__ = 'scrapyhistory'
-__version__ = '0.10.2'
+__version__ = '0.10.3'

--- a/history/logic.py
+++ b/history/logic.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 from datetime import datetime
 
 from scrapy.utils.httpobj import urlparse_cached
+from six.moves import map
 
 
 class LogicBase(object):
@@ -10,7 +12,7 @@ class LogicBase(object):
     def __init__(self, settings):
         self.ignore_missing = settings.getbool('HTTPCACHE_IGNORE_MISSING', False)
         self.ignore_schemes = settings.getlist('HTTPCACHE_IGNORE_SCHEMES', ['file'])
-        self.ignore_http_codes = map(int, settings.getlist('HTTPCACHE_IGNORE_HTTP_CODES', []))
+        self.ignore_http_codes = list(map(int, settings.getlist('HTTPCACHE_IGNORE_HTTP_CODES', [])))
 
     def spider_opened(self, spider):
         pass

--- a/history/logic.py
+++ b/history/logic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 
 from scrapy.utils.httpobj import urlparse_cached

--- a/history/middleware.py
+++ b/history/middleware.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 import logging
 

--- a/history/middleware.py
+++ b/history/middleware.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 from datetime import datetime
 import logging
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -2,12 +2,13 @@
 
 from __future__ import unicode_literals
 
+from __future__ import absolute_import
 import base64
 from datetime import datetime
 import json
 import logging
 import os
-import urllib
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
 import boto
 from scrapy.exceptions import NotConfigured
@@ -240,7 +241,7 @@ class S3CacheStorage(object):
             # if the S3 key is too long, the AWS interface does not allow to download the file !
             source_url = _truncate_url(request.url)
             source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request),
-                                                    urllib.quote_plus(source_url))
+                                                    six.moves.urllib.parse.quote_plus(source_url))
             source_key = self.s3_bucket.new_key(source_name)
             source_key.set_contents_from_string(response.body)
             # sometimes can cause memory error in SH if too big

--- a/history/storage.py
+++ b/history/storage.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import base64
 from datetime import datetime
 import json
 import logging
 import os
-import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
 import boto
+from six.moves.urllib import parse
 from scrapy.exceptions import NotConfigured
 from scrapy.http import TextResponse, Headers
 from scrapy.responsetypes import responsetypes
@@ -241,7 +239,7 @@ class S3CacheStorage(object):
             # if the S3 key is too long, the AWS interface does not allow to download the file !
             source_url = _truncate_url(request.url)
             source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request),
-                                                    six.moves.urllib.parse.quote_plus(source_url))
+                                                    parse.quote_plus(source_url))
             source_key = self.s3_bucket.new_key(source_name)
             source_key.set_contents_from_string(response.body)
             # sometimes can cause memory error in SH if too big

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 try:
     from setuptools import setup
 except ImportError:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import unittest
 from datetime import datetime
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import unittest
 from datetime import datetime
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+# Choose your Python versions. They have to be available
+# on the system the tests are run on.
+envlist = py27, py36
+
+# Tell tox to not require a setup.py file
+skipsdist = True
+
+[testenv]
+# use tools not contained in virtualenv
+passenv = *
+whitelist_externals = mkdir
+deps =
+  -rdev-requirements.txt
+  -rrequirements.txt
+
+commands= 
+  mkdir -p {env:CIRCLE_TEST_REPORTS:}/tests/{envname}/nosetests
+  mkdir -p {env:CIRCLE_TEST_REPORTS:}/tests/{envname}/coverage
+
+  nosetests {posargs:-v --with-timer \
+  --with-xunit --xunit-file={env:CIRCLE_TEST_REPORTS:}/tests/{envname}/nosetests/tests.xml \
+  --with-coverage --cover-min-percentage=37 --cover-html --cover-erase --cover-package=history \
+  --cover-html-dir={env:CIRCLE_TEST_REPORTS:}/tests/{envname}/coverage/history}


### PR DESCRIPTION
1- Run modernize command to turn py2 code into a six-compatible code (py27 + py36)
2- Edit result manually
3- Test code and dependencies installation with `tox` command for both python versions